### PR TITLE
Spelling fix and adding info

### DIFF
--- a/DownloadProject.cmake
+++ b/DownloadProject.cmake
@@ -83,6 +83,36 @@
 #
 #   add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
 #
+#
+# SOURCE:
+#
+#  https://github.com/Crascit/DownloadProject
+#
+# LICENSE:
+#
+#  The MIT License (MIT)
+# 
+#  Copyright (c) 2015 Crascit
+# 
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+# 
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+# 
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+#
+
 #========================================================================================
 
 

--- a/DownloadProject.cmake
+++ b/DownloadProject.cmake
@@ -73,7 +73,7 @@
 #
 # EXAMPLE USAGE:
 #
-#   include(download_project.cmake)
+#   include(DownloadProject)
 #   download_project(PROJ                googletest
 #                    GIT_REPOSITORY      https://github.com/google/googletest.git
 #                    GIT_TAG             master


### PR DESCRIPTION
I've fixed the typo in the example (first commit) and added the source and license (second commit, requested in #17 ) to the main file. If you don't want the second commit, the first is still useful.