### PR TITLE
Fix spelling in example

### DIFF
--- a/DownloadProject.cmake
+++ b/DownloadProject.cmake
@@ -73,7 +73,7 @@
 #
 # EXAMPLE USAGE:
 #
-#   include(download_project.cmake)
+#   include(DownloadProject)
 #   download_project(PROJ                googletest
 #                    GIT_REPOSITORY      https://github.com/google/googletest.git
 #                    GIT_TAG             master


### PR DESCRIPTION
The example calls this file `DownloadProject` instead of `download_project`. The `.cmake` is not needed. I recommend mentioning that you can add it to your cmake (modules) sub-directory, too.