### PR TITLE
Adding a license header

### DIFF
--- a/DownloadProject.CMakeLists.cmake.in
+++ b/DownloadProject.CMakeLists.cmake.in
@@ -1,3 +1,6 @@
+# Distributed under the OSI-approved MIT License.  See accompanying
+# file LICENSE or https://github.com/Crascit/DownloadProject for details.
+
 cmake_minimum_required(VERSION 2.8.2)
 
 project(${DL_ARGS_PROJ}-download NONE)

--- a/DownloadProject.cmake
+++ b/DownloadProject.cmake
@@ -1,3 +1,6 @@
+# Distributed under the OSI-approved MIT License.  See accompanying
+# file LICENSE or https://github.com/Crascit/DownloadProject for details.
+#
 # MODULE:   DownloadProject
 #
 # PROVIDES:


### PR DESCRIPTION
This adds a license header as discussed in #17, following the example of the CMake source. This also points back to the original repo.